### PR TITLE
Correct spelling of 'extras_require'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='mbdata',
           'contextlib2; python_version < "3.2"',
           'typing; python_version < "3"',
       ],
-      extra_require={
+      extras_require={
           'mbslave': ['psycopg2'],
           'sqlalchemy': ['sqlalchemy'],
       },


### PR DESCRIPTION
This fixes #13, and enables proper installing of extras directly via pip.