### PR TITLE
Update import for psycopg 2.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,6 @@ Installation
        sudo su - postgres
        createuser musicbrainz
        createdb -l C -E UTF-8 -T template0 -O musicbrainz musicbrainz
-       createlang plpgsql musicbrainz
        psql musicbrainz -c 'CREATE EXTENSION cube;'
        psql musicbrainz -c 'CREATE EXTENSION earthdistance;'
 

--- a/mbdata/replication.py
+++ b/mbdata/replication.py
@@ -245,7 +245,7 @@ def load_tar(filename, db, config, ignored_schemas, ignored_tables):
             logger.info("Skipping %s (table %s already contains data)", name, fulltable)
             continue
         logger.info("Loading %s to %s", name, fulltable)
-        cursor.copy_from(tar.extractfile(member), fulltable)
+        cursor.copy_expert(f'COPY {fulltable} FROM STDIN', tar.extractfile(member))
         db.commit()
 
 

--- a/mbdata/replication.py
+++ b/mbdata/replication.py
@@ -245,7 +245,7 @@ def load_tar(filename, db, config, ignored_schemas, ignored_tables):
             logger.info("Skipping %s (table %s already contains data)", name, fulltable)
             continue
         logger.info("Loading %s to %s", name, fulltable)
-        cursor.copy_expert(f'COPY {fulltable} FROM STDIN', tar.extractfile(member))
+        cursor.copy_expert('COPY {} FROM STDIN'.format(fulltable), tar.extractfile(member))
         db.commit()
 
 

--- a/scripts/create_sample_db.py
+++ b/scripts/create_sample_db.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import print_function
 import os
 import sys

--- a/scripts/create_sample_db.py
+++ b/scripts/create_sample_db.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import print_function
 import os
 import sys


### PR DESCRIPTION
### Import Update
Updated the cursor copy function for psycopg 2.9 changes, per the suggestions in https://github.com/psycopg/psycopg2/issues/1294.

This should resolve issues #22  and #27 .

---

### Readme Update
Removed the following line from the Readme because PL/pgSQL is now available as a standard in any newly created Postgres database:
`createlang plpgsql musicbrainz`